### PR TITLE
fix(cmake): enforce 16KB ELF alignment for SmartCropper build

### DIFF
--- a/smartcropperlib/CMakeLists.txt
+++ b/smartcropperlib/CMakeLists.txt
@@ -13,10 +13,8 @@ set(OPENCV_3RD_LIB_DIR opencv/3rdparty/${ANDROID_ABI}/)
 include_directories(opencv/include
                     src/main/cpp/include)
 
-
 link_directories(${OPENCV_LIB_DIR}
                  ${OPENCV_3RD_LIB_DIR})
-
 
 # Creates and names a library, sets it as either STATIC
 # or SHARED, and provides the relative paths to its source code.
@@ -26,6 +24,11 @@ link_directories(${OPENCV_LIB_DIR}
 aux_source_directory(${SRC_DIR} DIR_LIB_SOURCE)
 
 add_library(${TARGET} SHARED ${DIR_LIB_SOURCE})
+
+# Forces ELF segment alignment to 16KB for compatibility with Android 15+
+# This is required by Google Play when compiling with NDK r26 or earlier
+# to support devices that use 16 KB page sizes.
+target_link_options(${TARGET} PRIVATE "-Wl,-z,max-page-size=16384")
 
 # Searches for a specified prebuilt library and stores the path as a
 # variable. Because CMake includes system libraries in the search path by
@@ -40,8 +43,7 @@ target_link_libraries(${TARGET} log jnigraphics z)
 # build script, prebuilt third-party libraries, or system libraries.
 
 if(${ANDROID_ABI} STREQUAL x86 OR ${ANDROID_ABI} STREQUAL x86_64)
-target_link_libraries(${TARGET} opencv_imgproc opencv_core ippiw ippicv ittnotify tbb cpufeatures)
+    target_link_libraries(${TARGET} opencv_imgproc opencv_core ippiw ippicv ittnotify tbb cpufeatures)
 else()
-target_link_libraries(${TARGET} opencv_imgproc opencv_core tegra_hal tbb cpufeatures)
+    target_link_libraries(${TARGET} opencv_imgproc opencv_core tegra_hal tbb cpufeatures)
 endif()
-


### PR DESCRIPTION
### Fix: Enable 16KB ELF Alignment in SmartCropper CMake Build

This PR updates the **CMake configuration** for SmartCropper to enforce **16KB ELF alignment** when compiling with **Android NDK r26 and lower**.  
This change ensures that the generated native libraries (`.so`) meet the upcoming **Google Play requirement** for devices with **16KB page sizes** starting **November 2025**.

#### Changes:
- Added `target_link_options` with `-Wl,-z,max-page-size=16384` in `CMakeLists.txt`.
- Ensures compatibility with **Android 15+** and future Google Play policy enforcement.

#### References:
- [Android 16KB Page Sizes — Official Guide](https://developer.android.com/guide/practices/page-sizes)  
- [Compiling for NDK r26 and Lower](https://developer.android.com/guide/practices/page-sizes#compile-r26-lower)